### PR TITLE
Add documentation for VS Code type error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -29,5 +29,20 @@ You will also see any lint errors in the console.
 
 Launches the test runner in the interactive watch mode.
 
-Tests are written with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro). 
+Tests are written with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
 
+## Troubleshooting
+
+### VS Code - Complex union type type error
+
+If you are using VS Code and encounter the following type error:
+
+```
+Expression produces a union type that is too complex to represent.ts(2590)
+```
+
+you can resolve it by switching from the default VS Code TypeScript version and the workspace version:
+
+1. Open the Command Palette (cmd + shift + p on Mac)
+2. Type in `TypeScript: Select TypeScript version command`
+3. Select `Use workspace Version - node_modules/typescript/lib`


### PR DESCRIPTION
Noticed a distracting type error related to VS Code TypeScript versioning that may affect others using VS Code

https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript